### PR TITLE
Update GridPartitioner

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrixSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrixSuite.scala
@@ -17,8 +17,10 @@
 
 package org.apache.spark.mllib.linalg.distributed
 
-import org.scalatest.FunSuite
+import scala.util.Random
+
 import breeze.linalg.{DenseMatrix => BDM}
+import org.scalatest.FunSuite
 
 import org.apache.spark.mllib.linalg.{DenseMatrix, Matrices, Matrix}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
@@ -51,50 +53,72 @@ class BlockMatrixSuite extends FunSuite with MLlibTestSparkContext {
     assert(gridBasedMat.numCols() === n)
   }
 
-  test("grid partitioner partitioning") {
-    val partitioner = gridBasedMat.partitioner
-    assert(partitioner.getPartition((0, 0)) === 0)
-    assert(partitioner.getPartition((0, 1)) === 0)
-    assert(partitioner.getPartition((1, 0)) === 1)
-    assert(partitioner.getPartition((1, 1)) === 1)
-    assert(partitioner.getPartition((2, 0)) === 2)
-    assert(partitioner.getPartition((2, 1)) === 2)
-    assert(partitioner.getPartition((1, 0, 1)) === 1)
-    assert(partitioner.getPartition((2, 0, 0)) === 2)
-
-    val part2 = new GridPartitioner(10, 20, 10)
-    assert(part2.getPartition((0, 0)) === 0)
-    assert(part2.getPartition((0, 1)) === 0)
-    assert(part2.getPartition((0, 6)) === 2)
-    assert(part2.getPartition((3, 7)) === 2)
-    assert(part2.getPartition((3, 8)) === 4)
-    assert(part2.getPartition((3, 13)) === 6)
-    assert(part2.getPartition((9, 14)) === 7)
-    assert(part2.getPartition((9, 15)) === 7)
-    assert(part2.getPartition((9, 19)) === 9)
-
-    intercept[IllegalArgumentException] {
-      part2.getPartition((-1, 0))
+  test("grid partitioner") {
+    val random = new Random()
+    // This should generate a 4x4 grid of 1x2 blocks.
+    val part0 = GridPartitioner(4, 7, suggestedNumPartitions = 12)
+    val expected0 = Array(
+      Array(0, 0, 4, 4,  8,  8, 12),
+      Array(1, 1, 5, 5,  9,  9, 13),
+      Array(2, 2, 6, 6, 10, 10, 14),
+      Array(3, 3, 7, 7, 11, 11, 15))
+    for (i <- 0 until 4; j <- 0 until 7) {
+      assert(part0.getPartition((i, j)) === expected0(i)(j))
+      assert(part0.getPartition((i, j, random.nextInt())) === expected0(i)(j))
     }
 
     intercept[IllegalArgumentException] {
-      part2.getPartition((10, 0))
+      part0.getPartition((-1, 0))
     }
 
     intercept[IllegalArgumentException] {
-      part2.getPartition((9, 20))
+      part0.getPartition((4, 0))
     }
 
-    val part3 = new GridPartitioner(20, 10, 10)
-    assert(part3.getPartition((0, 0)) === 0)
-    assert(part3.getPartition((1, 0)) === 0)
-    assert(part3.getPartition((6, 0)) === 1)
-    assert(part3.getPartition((7, 3)) === 1)
-    assert(part3.getPartition((8, 3)) === 2)
-    assert(part3.getPartition((13, 3)) === 3)
-    assert(part3.getPartition((14, 9)) === 8)
-    assert(part3.getPartition((15, 9)) === 8)
-    assert(part3.getPartition((19, 9)) === 9)
+    intercept[IllegalArgumentException] {
+      part0.getPartition((0, -1))
+    }
+
+    intercept[IllegalArgumentException] {
+      part0.getPartition((0, 7))
+    }
+
+    val part1 = GridPartitioner(2, 2, suggestedNumPartitions = 5)
+    val expected1 = Array(
+      Array(0, 2),
+      Array(1, 3))
+    for (i <- 0 until 2; j <- 0 until 2) {
+      assert(part1.getPartition((i, j)) === expected1(i)(j))
+      assert(part1.getPartition((i, j, random.nextInt())) === expected1(i)(j))
+    }
+
+    val part2 = GridPartitioner(2, 2, suggestedNumPartitions = 5)
+    assert(part0 !== part2)
+    assert(part1 === part2)
+
+    val part3 = new GridPartitioner(2, 3, rowsPerPart = 1, colsPerPart = 2)
+    val expected3 = Array(
+      Array(0, 0, 2),
+      Array(1, 1, 3))
+    for (i <- 0 until 2; j <- 0 until 3) {
+      assert(part3.getPartition((i, j)) === expected3(i)(j))
+      assert(part3.getPartition((i, j, random.nextInt())) === expected3(i)(j))
+    }
+
+    val part4 = GridPartitioner(2, 3, rowsPerPart = 1, colsPerPart = 2)
+    assert(part3 === part4)
+
+    intercept[IllegalArgumentException] {
+      new GridPartitioner(2, 2, rowsPerPart = 0, colsPerPart = 1)
+    }
+
+    intercept[IllegalArgumentException] {
+      GridPartitioner(2, 2, rowsPerPart = 1, colsPerPart = 0)
+    }
+
+    intercept[IllegalArgumentException] {
+      GridPartitioner(2, 2, suggestedNumPartitions = 0)
+    }
   }
 
   test("toBreeze and toLocalMatrix") {

--- a/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrixSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/linalg/distributed/BlockMatrixSuite.scala
@@ -33,19 +33,18 @@ class BlockMatrixSuite extends FunSuite with MLlibTestSparkContext {
   val colPerPart = 2
   val numPartitions = 3
   var gridBasedMat: BlockMatrix = _
-  type SubMatrix = ((Int, Int), Matrix)
 
   override def beforeAll() {
     super.beforeAll()
 
-    val entries: Seq[SubMatrix] = Seq(
-      new SubMatrix((0, 0), new DenseMatrix(2, 2, Array(1.0, 0.0, 0.0, 2.0))),
-      new SubMatrix((0, 1), new DenseMatrix(2, 2, Array(0.0, 1.0, 0.0, 0.0))),
-      new SubMatrix((1, 0), new DenseMatrix(2, 2, Array(3.0, 0.0, 1.0, 1.0))),
-      new SubMatrix((1, 1), new DenseMatrix(2, 2, Array(1.0, 2.0, 0.0, 1.0))),
-      new SubMatrix((2, 1), new DenseMatrix(1, 2, Array(1.0, 5.0))))
+    val blocks: Seq[((Int, Int), Matrix)] = Seq(
+      ((0, 0), new DenseMatrix(2, 2, Array(1.0, 0.0, 0.0, 2.0))),
+      ((0, 1), new DenseMatrix(2, 2, Array(0.0, 1.0, 0.0, 0.0))),
+      ((1, 0), new DenseMatrix(2, 2, Array(3.0, 0.0, 1.0, 1.0))),
+      ((1, 1), new DenseMatrix(2, 2, Array(1.0, 2.0, 0.0, 1.0))),
+      ((2, 1), new DenseMatrix(1, 2, Array(1.0, 5.0))))
 
-    gridBasedMat = new BlockMatrix(sc.parallelize(entries, numPartitions), rowPerPart, colPerPart)
+    gridBasedMat = new BlockMatrix(sc.parallelize(blocks, numPartitions), rowPerPart, colPerPart)
   }
 
   test("size") {


### PR DESCRIPTION
@brkyvz I made some changes to GridPartitioner:

1. use rowsPerPart and colsPerPart to the constructor to be specific
2. move the suggestedNumPartitions to `object GridPartitioner` and simplify the logic a little bit
3. move the inner index to the third position, so when keys are ordered we have (i, j, k0), (i, j, k1), ...

It also contains some minor updates.