### PR TITLE
First resolve stddev functions to Hive's GenericUDAF and then replace them to our native functions.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/functions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/functions.scala
@@ -406,4 +406,12 @@ case class StandardDeviation(child: Expression, sample: Boolean) extends Algebra
         Sqrt(Cast(currentMk, resultType) / Cast(count, resultType))
     }
   }
+
+  override def prettyName: String = {
+    if (sample) {
+      "stddev_samp"
+    } else {
+      "stddev_pop"
+    }
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrame.scala
@@ -1273,7 +1273,7 @@ class DataFrame private[sql](
     val statistics = List[(String, Expression => Expression)](
       "count" -> Count,
       "mean" -> Average,
-      "stddev" -> aggregate.Utils.sampleStandardDeviation,
+      "stddev" -> ((e: Expression) => UnresolvedFunction("stddev_samp", e :: Nil, false)),
       "min" -> Min,
       "max" -> Max)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/GroupedData.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/GroupedData.scala
@@ -21,7 +21,7 @@ import scala.collection.JavaConversions._
 import scala.language.implicitConversions
 
 import org.apache.spark.annotation.Experimental
-import org.apache.spark.sql.catalyst.analysis.{UnresolvedAlias, UnresolvedAttribute, Star}
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedFunction, UnresolvedAlias, UnresolvedAttribute, Star}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.{Rollup, Cube, Aggregate}
 import org.apache.spark.sql.types.NumericType
@@ -304,8 +304,12 @@ class GroupedData protected[sql](
    */
   @scala.annotation.varargs
   def stddevPop(colNames: String*): DataFrame = {
-    aggregateNumericColumns(colNames : _*)(aggregate.Utils.standardDeviation(_, sample = false,
-      "stddev_pop"))
+    val builder = (e: Expression) => {
+      Alias(
+        UnresolvedFunction("stddev_pop", e :: Nil, false),
+        s"stddev_pop(${e.prettyString})")()
+    }
+    aggregateNumericColumns(colNames : _*)(builder)
   }
 
   /**
@@ -317,7 +321,12 @@ class GroupedData protected[sql](
    */
   @scala.annotation.varargs
   def stddevSamp(colNames: String*): DataFrame = {
-    aggregateNumericColumns(colNames : _*)(aggregate.Utils.sampleStandardDeviation)
+    val builder = (e: Expression) => {
+        Alias(
+          UnresolvedFunction("stddev_samp", e :: Nil, false),
+          s"stddev_samp(${e.prettyString})")()
+      }
+    aggregateNumericColumns(colNames : _*)(builder)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortBasedAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/SortBasedAggregate.scala
@@ -98,6 +98,10 @@ case class SortBasedAggregate(
 
   override def simpleString: String = {
     val allAggregateExpressions = nonCompleteAggregateExpressions ++ completeAggregateExpressions
-    s"""SortBasedAggregate ${groupingExpressions} ${allAggregateExpressions}"""
+
+    val keyString = groupingExpressions.mkString("[", ",", "]")
+    val valueString = allAggregateExpressions.mkString("[", ",", "]")
+    val outputString = output.mkString("[", ",", "]")
+    s"SortBasedAggregate(key=$keyString, functions=$valueString, output=$outputString)"
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/TungstenAggregate.scala
@@ -96,10 +96,11 @@ case class TungstenAggregate(
       case None =>
         val keyString = groupingExpressions.mkString("[", ",", "]")
         val valueString = allAggregateExpressions.mkString("[", ",", "]")
-        s"TungstenAggregate(key=$keyString, value=$valueString"
+        val outputString = output.mkString("[", ",", "]")
+        s"TungstenAggregate(key=$keyString, functions=$valueString, output=$outputString)"
       case Some(fallbackStartsAt) =>
         s"TungstenAggregateWithControlledFallback $groupingExpressions " +
-          s"$allAggregateExpressions fallbackStartsAt=$fallbackStartsAt"
+          s"$allAggregateExpressions $resultExpressions fallbackStartsAt=$fallbackStartsAt"
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -310,7 +310,7 @@ object functions {
    * @group agg_funcs
    * @since 1.5.0
    */
-  def stddev(columnName: String): Column = stddev(Column(columnName))
+  def stddev(columnName: String): Column = stddevSamp(Column(columnName))
 
   /**
    * Aggregate function: returns the population standard deviation of the values in a group.
@@ -318,7 +318,11 @@ object functions {
    * @group agg_funcs
    * @since 1.5.0
    */
-  def stddevPop(e: Column): Column = aggregate.Utils.standardDeviation(e.expr, false, "stddev_pomp")
+  def stddevPop(e: Column): Column = {
+    Alias(
+      UnresolvedFunction("stddev_pop", e.expr :: Nil, false),
+      s"stddev_pop(${e.expr.prettyString})")()
+  }
 
   /**
    * Aggregate function: returns the population standard deviation of the values in a group.
@@ -334,7 +338,11 @@ object functions {
    * @group agg_funcs
    * @since 1.5.0
    */
-  def stddevSamp(e: Column): Column = aggregate.Utils.sampleStandardDeviation(e.expr)
+  def stddevSamp(e: Column): Column = {
+    Alias(
+      UnresolvedFunction("stddev_samp", e.expr :: Nil, false),
+      s"stddev_samp(${e.expr.prettyString})")()
+  }
 
   /**
    * Aggregate function: returns the sample standard deviation of the values in a group.
@@ -342,7 +350,7 @@ object functions {
    * @group agg_funcs
    * @since 1.5.0
    */
-  def stddevSamp(columnName: String): Column = stddev(Column(columnName))
+  def stddevSamp(columnName: String): Column = stddevSamp(Column(columnName))
 
   /**
    * Aggregate function: returns the sum of all values in the expression.

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -21,8 +21,6 @@ import java.util.{Locale, TimeZone}
 
 import scala.collection.JavaConversions._
 
-import org.scalactic.TripleEqualsSupport.Spread
-
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.columnar.InMemoryRelation


### PR DESCRIPTION
So, if we could not evaluate all aggregate functions with our new code path (if there is a function that is not supported in the new code path), we can just use Hive's UDAF.